### PR TITLE
Atualiza checkstyle para versão 9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-alpine
 
 ENV REVIEWDOG_VERSION=v0.12.0
 
-ENV CHECKSTYLE_VERSION=8.42
+ENV CHECKSTYLE_VERSION=9.3
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
Estamos atualizando o base para o java 17 e, para que o checkstyle suporte as novas ferramentas da linguagem, este é atualizado para a versão 9.3 neste PR.